### PR TITLE
Fix accordion expansion behavior on button clicks

### DIFF
--- a/source/js/modularity-guides.ts
+++ b/source/js/modularity-guides.ts
@@ -6,7 +6,7 @@ const SELECTOR_MODULARITY_GUIDE = '.js-modularity-guide';
 const SELECTOR_SECTION = '.js-modularity-guide__section';
 const SELECTOR_NEXT = '.js-modularity-guide__next';
 const SELECTOR_PREV = '.js-modularity-guide__prev';
-const SELECTOR_ACCORDION_TOGGLE = 'open';
+const ATTRIBUTE_STATE = 'open';
 
 // Required data-attributes
 const ATTRIBUTE_STEP = 'data-guide-step';
@@ -32,9 +32,9 @@ function handlePrevNextClick(e: Event) {
 		const targetSection = currentGuide?.querySelector(`[${ATTRIBUTE_STEP}="${targetStep}"]`);
 
 		currentGuide?.querySelectorAll(`[${ATTRIBUTE_STEP}]`).forEach((elem) => {
-			elem.removeAttribute(SELECTOR_ACCORDION_TOGGLE);
+			elem.removeAttribute(ATTRIBUTE_STATE);
 		});
-		targetSection?.setAttribute(SELECTOR_ACCORDION_TOGGLE, '');
+		targetSection?.setAttribute(ATTRIBUTE_STATE, '');
 	}
 }
 

--- a/source/js/modularity-guides.ts
+++ b/source/js/modularity-guides.ts
@@ -6,7 +6,7 @@ const SELECTOR_MODULARITY_GUIDE = '.js-modularity-guide';
 const SELECTOR_SECTION = '.js-modularity-guide__section';
 const SELECTOR_NEXT = '.js-modularity-guide__next';
 const SELECTOR_PREV = '.js-modularity-guide__prev';
-const SELECTOR_ACCORDION_TOGGLE = '[js-expand-button]';
+const SELECTOR_ACCORDION_TOGGLE = 'open';
 
 // Required data-attributes
 const ATTRIBUTE_STEP = 'data-guide-step';
@@ -30,11 +30,11 @@ function handlePrevNextClick(e: Event) {
 	if (currentStep > 0) {
 		const targetStep = isNext ? currentStep + 1 : currentStep - 1;
 		const targetSection = currentGuide?.querySelector(`[${ATTRIBUTE_STEP}="${targetStep}"]`);
-		const targetToggle = targetSection?.querySelector(SELECTOR_ACCORDION_TOGGLE) as HTMLButtonElement;
 
-		if (targetToggle) {
-			targetToggle.click();
-		}
+		currentGuide?.querySelectorAll('[data-guide-step]').forEach((e) => {
+			e.removeAttribute(SELECTOR_ACCORDION_TOGGLE);
+		});
+		targetSection?.setAttribute(SELECTOR_ACCORDION_TOGGLE, '');
 	}
 }
 

--- a/source/js/modularity-guides.ts
+++ b/source/js/modularity-guides.ts
@@ -31,8 +31,8 @@ function handlePrevNextClick(e: Event) {
 		const targetStep = isNext ? currentStep + 1 : currentStep - 1;
 		const targetSection = currentGuide?.querySelector(`[${ATTRIBUTE_STEP}="${targetStep}"]`);
 
-		currentGuide?.querySelectorAll('[data-guide-step]').forEach((e) => {
-			e.removeAttribute(SELECTOR_ACCORDION_TOGGLE);
+		currentGuide?.querySelectorAll('[data-guide-step]').forEach((elem) => {
+			elem.removeAttribute(SELECTOR_ACCORDION_TOGGLE);
 		});
 		targetSection?.setAttribute(SELECTOR_ACCORDION_TOGGLE, '');
 	}

--- a/source/js/modularity-guides.ts
+++ b/source/js/modularity-guides.ts
@@ -31,7 +31,7 @@ function handlePrevNextClick(e: Event) {
 		const targetStep = isNext ? currentStep + 1 : currentStep - 1;
 		const targetSection = currentGuide?.querySelector(`[${ATTRIBUTE_STEP}="${targetStep}"]`);
 
-		currentGuide?.querySelectorAll('[data-guide-step]').forEach((elem) => {
+		currentGuide?.querySelectorAll(`[${ATTRIBUTE_STEP}]`).forEach((elem) => {
 			elem.removeAttribute(SELECTOR_ACCORDION_TOGGLE);
 		});
 		targetSection?.setAttribute(SELECTOR_ACCORDION_TOGGLE, '');


### PR DESCRIPTION
This pull request updates the way accordion sections are toggled in the modularity guides navigation logic. The main change is a shift from simulating button clicks to directly manipulating the `open` attribute for accordion state management.

**Accordion toggle logic update:**

* Changed the `SELECTOR_ACCORDION_TOGGLE` constant from a button selector to the `open` attribute, reflecting a move to attribute-based state management.
* Updated the `handlePrevNextClick` function to remove the `open` attribute from all sections before setting it on the target section, instead of triggering a button click. This makes the accordion behavior more direct and reliable.