### PR TITLE
Remove jQuery dependency from the project

### DIFF
--- a/source/js/Content/Checkboxes.ts
+++ b/source/js/Content/Checkboxes.ts
@@ -13,7 +13,7 @@ export default (() => {
 	 */
 	function handleRelationChange(e: Event) {
 		const checkbox = e.currentTarget as HTMLInputElement;
-		const relations = (checkbox.getAttribute(ATTRIBUTE_RELATION) ?? '').split(',');
+		const relations = (checkbox.getAttribute(ATTRIBUTE_RELATION) ?? '').split(',').map((item) => item.trim()).filter((item) => item !== '');
 
 		relations.forEach((item) => {
 			const relatedCheckbox = document.querySelector<HTMLInputElement>(
@@ -48,7 +48,7 @@ export default (() => {
 
 		document.querySelectorAll<HTMLElement>(SELECTOR_TOGGLE_KEY_CONTENT).forEach((element) => {
 			let shouldShow = false;
-			const conditions = (element.getAttribute(ATTRIBUTE_TOGGLE_KEY_CONTENT) ?? '').split(',');
+			const conditions = (element.getAttribute(ATTRIBUTE_TOGGLE_KEY_CONTENT) ?? '').split(',').map((item) => item.trim()).filter((item) => item !== '');
 
 			conditions.forEach((item) => {
 				const and = item.match(/(^|\+)([^+-]+)/g);

--- a/source/js/Content/Checkboxes.ts
+++ b/source/js/Content/Checkboxes.ts
@@ -1,66 +1,65 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const jQuery: any;
+export default (() => {
+	const SELECTOR_RELATION_CHECKBOX = 'input[type="checkbox"][data-mod-guide-relation]';
+	const SELECTOR_TOGGLE_KEY = '[data-mod-guide-toggle-key]';
+	const SELECTOR_TODO_WIDGET = '[data-mod-guide-todo-widget]';
+	const SELECTOR_TOGGLE_KEY_CONTENT = '[data-mod-guide-toggle-key-content]';
+	const ATTRIBUTE_RELATION = 'data-mod-guide-relation';
+	const ATTRIBUTE_TOGGLE_KEY = 'data-mod-guide-toggle-key';
+	const ATTRIBUTE_TOGGLE_KEY_CONTENT = 'data-mod-guide-toggle-key-content';
 
-export default (($) => {
-	function Checkboxes() {
-		// @ts-expect-error Needs refactoring
-		this.handleEvents();
-		// @ts-expect-error Needs refactoring
-		this.contentToggleEngine();
-	}
+	/**
+	 * Toggle checkboxes related to the changed checkbox, based on data-mod-guide-relation
+	 * @param {Event} e change event
+	 */
+	function handleRelationChange(e: Event) {
+		const checkbox = e.currentTarget as HTMLInputElement;
+		const relations = (checkbox.getAttribute(ATTRIBUTE_RELATION) ?? '').split(',');
 
-	Checkboxes.prototype.handleEvents = function () {
-		$('input[type="checkbox"][data-mod-guide-relation]').on('change', function () {
-			// @ts-expect-error Needs refactoring
-			let relations = $(this).data('mod-guide-relation');
-			relations = relations.split(',');
+		relations.forEach((item) => {
+			const relatedCheckbox = document.querySelector<HTMLInputElement>(
+				`input[type="checkbox"][${ATTRIBUTE_TOGGLE_KEY}="${item}"]`,
+			);
 
-			$.each(relations, (_: number, item: string) => {
-				const $cb = $('input[type="checkbox"][data-mod-guide-toggle-key="' + item + '"]');
-				$cb.prop('checked', !$cb.prop('checked')).trigger('change');
-			});
-		});
-
-		$('[data-mod-guide-toggle-key]').on(
-			'change',
-			function () {
-				// @ts-expect-error Needs refactoring
-				this.contentToggleEngine();
-			}.bind(this),
-		);
-	};
-
-	Checkboxes.prototype.contentToggleEngine = () => {
-		// Get checked checkboxes
-		const checked: string[] = [];
-		const $checkboxes = $('[data-mod-guide-toggle-key]');
-
-		$checkboxes.each((_: number, element: Element) => {
-			if ($(element).prop('checked') !== true) {
+			if (!relatedCheckbox) {
 				return;
 			}
-			checked.push($(element).attr('data-mod-guide-toggle-key'));
+
+			relatedCheckbox.checked = !relatedCheckbox.checked;
+			relatedCheckbox.dispatchEvent(new Event('change'));
 		});
-		// Hide all todo widgets
-		$('[data-mod-guide-todo-widget]').each((_: number, element: Element) => $(element).hide());
+	}
 
-		// Display or hide content
-		$('[data-mod-guide-toggle-key-content]').each((_: number, element: Element) => {
+	/**
+	 * Show or hide content based on which toggle keys are currently checked
+	 */
+	function contentToggleEngine() {
+		const checked: string[] = [];
+
+		document.querySelectorAll<HTMLInputElement>(SELECTOR_TOGGLE_KEY).forEach((element) => {
+			if (element.checked !== true) {
+				return;
+			}
+			checked.push(element.getAttribute(ATTRIBUTE_TOGGLE_KEY) ?? '');
+		});
+
+		document.querySelectorAll<HTMLElement>(SELECTOR_TODO_WIDGET).forEach((element) => {
+			element.style.display = 'none';
+		});
+
+		document.querySelectorAll<HTMLElement>(SELECTOR_TOGGLE_KEY_CONTENT).forEach((element) => {
 			let shouldShow = false;
-			let conditions = $(element).attr('data-mod-guide-toggle-key-content');
-			conditions = conditions.split(',');
+			const conditions = (element.getAttribute(ATTRIBUTE_TOGGLE_KEY_CONTENT) ?? '').split(',');
 
-			// Datermind if content should be shown or not
-			$.each(conditions, (_: number, item: string) => {
+			conditions.forEach((item) => {
 				const and = item.match(/(^|\+)([^+-]+)/g);
-				const andPattern = new RegExp('\\b(' + and?.join('|').replace('+', '') + ')\\b', 'ig');
+				const andPattern = new RegExp(`\\b(${and?.join('|').replace('+', '')})\\b`, 'ig');
 				const andMatches = checked.join(',').match(andPattern);
 				const andIsMatching = andMatches !== null && andMatches.length === and?.length;
 
 				const andnot = item.match(/-([^+-]+)/g);
 				let andnotIsMatching = true;
 				if (andnot !== null) {
-					const andnotPattern = new RegExp('\\b(' + andnot.join('|').replace('-', '') + ')\\b', 'ig');
+					const andnotPattern = new RegExp(`\\b(${andnot.join('|').replace('-', '')})\\b`, 'ig');
 					const andnotMatches = checked.join(',').match(andnotPattern);
 					andnotIsMatching = !(andnotMatches !== null && andnotMatches.length > 0);
 				}
@@ -70,19 +69,47 @@ export default (($) => {
 				}
 			});
 
-			// Hide or show
+			const row = element.closest<HTMLElement>('tr');
+
 			if (shouldShow) {
-				$(element).show();
-				$(element).closest('tr').show();
-				$(element).closest('[data-mod-guide-todo-widget]').show();
+				element.style.display = '';
+				if (row) {
+					row.style.display = '';
+				}
+				const todoWidget = element.closest<HTMLElement>(SELECTOR_TODO_WIDGET);
+				if (todoWidget) {
+					todoWidget.style.display = '';
+				}
 				return;
 			}
 
-			$(element).hide();
-			$(element).closest('tr').hide();
-			return;
+			element.style.display = 'none';
+			if (row) {
+				row.style.display = 'none';
+			}
 		});
-	};
-	// @ts-expect-error Needs refactoring
-	return new Checkboxes();
-})(jQuery);
+	}
+
+	/**
+	 * Subscribe checkbox relation & content toggle events
+	 */
+	function handleEvents() {
+		document.querySelectorAll<HTMLInputElement>(SELECTOR_RELATION_CHECKBOX).forEach((checkbox) => {
+			checkbox.addEventListener('change', handleRelationChange);
+		});
+
+		document.querySelectorAll<HTMLElement>(SELECTOR_TOGGLE_KEY).forEach((element) => {
+			element.addEventListener('change', contentToggleEngine);
+		});
+	}
+
+	/**
+	 * Subscribe events & set initial content visibility
+	 */
+	function init() {
+		handleEvents();
+		contentToggleEngine();
+	}
+
+	window.addEventListener('DOMContentLoaded', init);
+})();

--- a/source/js/modularity-guides.ts
+++ b/source/js/modularity-guides.ts
@@ -25,7 +25,7 @@ function handlePrevNextClick(e: Event) {
 	// Traverse DOM upwards
 	const currentGuide = prevNextButtonElement?.closest(SELECTOR_MODULARITY_GUIDE);
 	const currentSection = prevNextButtonElement?.closest(SELECTOR_SECTION);
-	const currentStep = parseInt(currentSection?.getAttribute(ATTRIBUTE_STEP) ?? '-1');
+	const currentStep = parseInt(currentSection?.getAttribute(ATTRIBUTE_STEP) ?? '-1', 10);
 
 	if (currentStep > 0) {
 		const targetStep = isNext ? currentStep + 1 : currentStep - 1;

--- a/source/js/modularity-guides.ts
+++ b/source/js/modularity-guides.ts
@@ -19,7 +19,7 @@ const ATTRIBUTE_STEP = 'data-guide-step';
 function handlePrevNextClick(e: Event) {
 	e.preventDefault();
 
-	const prevNextButtonElement = e.target as HTMLButtonElement;
+	const prevNextButtonElement = e.currentTarget as HTMLButtonElement;
 	const isNext = prevNextButtonElement?.classList.contains(SELECTOR_NEXT.substring(1));
 
 	// Traverse DOM upwards

--- a/source/php/Module.php
+++ b/source/php/Module.php
@@ -44,10 +44,6 @@ class Module extends \Modularity\Module
             ->with()
             ->translation('guides', $this->lang)
             ->add('css/modularity-guides.css', [], '1.0.0');
-
-        if (wp_script_is('jquery', 'registered') && !wp_script_is('jquery', 'enqueued')) {
-            wp_enqueue_script('jquery');
-        }
     }
 
     /**


### PR DESCRIPTION
This pull request refactors the `Checkboxes` module to remove its dependency on jQuery, modernizes event handling, and improves code clarity and maintainability. Additionally, it makes a small fix in `modularity-guides.ts` for parsing integers and removes unnecessary jQuery enqueuing in the PHP backend.

**Refactor and modernization of `Checkboxes` module:**

* Completely rewrote `source/js/Content/Checkboxes.ts` to use vanilla JavaScript instead of jQuery, including replacing all DOM selection, event handling, and style changes with standard APIs. This improves performance, maintainability, and removes reliance on jQuery. [[1]](diffhunk://#diff-8d52082fcffe6cff0045eaeccb927f45cb862d1f71eec9beb2509e20eee43bf4L1-R62) [[2]](diffhunk://#diff-8d52082fcffe6cff0045eaeccb927f45cb862d1f71eec9beb2509e20eee43bf4L73-R115)
* Modularized event subscription and initialization logic, ensuring that event listeners are attached after DOM content is loaded and that the initial content visibility is set on page load.

**General improvements:**

* Fixed integer parsing in `source/js/modularity-guides.ts` by explicitly specifying base 10 in `parseInt`, preventing potential bugs with non-decimal values.

**Backend cleanup:**

* Removed unnecessary jQuery enqueuing logic from `source/php/Module.php`, since the frontend no longer depends on jQuery.